### PR TITLE
refactor: 페이징Dto로 방식 통일, token 상수 해결

### DIFF
--- a/src/main/java/com/example/playcation/cart/controller/CartController.java
+++ b/src/main/java/com/example/playcation/cart/controller/CartController.java
@@ -3,9 +3,11 @@ package com.example.playcation.cart.controller;
 import com.example.playcation.cart.dto.CartGameResponseDto;
 import com.example.playcation.cart.dto.UpdatedCartGameResponseDto;
 import com.example.playcation.cart.service.CartService;
+import com.example.playcation.common.TokenSettings;
 import com.example.playcation.util.JWTUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.antlr.v4.runtime.Token;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,7 +34,7 @@ public class CartController {
    */
   @GetMapping
   public ResponseEntity<List<CartGameResponseDto>> findCartItems(
-      @RequestHeader("Authorization") String authorizationHeader) {
+      @RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader) {
     Long userId = jwtUtil.findUserByToken(authorizationHeader);
     List<CartGameResponseDto> games = cartService.findCartItems(userId);
 
@@ -48,7 +50,7 @@ public class CartController {
    */
   @PostMapping("/add/{gameId}")
   public ResponseEntity<UpdatedCartGameResponseDto> addGameToCart(@PathVariable Long gameId,
-      @RequestHeader("Authorization") String authorizationHeader) {
+      @RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader) {
     Long userId = jwtUtil.findUserByToken(authorizationHeader);
     UpdatedCartGameResponseDto updatedCart = cartService.addGameToCart(userId, gameId);
     return new ResponseEntity<>(updatedCart, HttpStatus.OK);
@@ -63,7 +65,7 @@ public class CartController {
    */
   @DeleteMapping("/delete/{gameId}")
   public ResponseEntity<String> deleteGameFromCart(@PathVariable Long gameId,
-      @RequestHeader("Authorization") String authorizationHeader) {
+      @RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader) {
     Long userId = jwtUtil.findUserByToken(authorizationHeader);
     cartService.deleteGameFromCart(userId, gameId);
     return new ResponseEntity<>("게임 삭제 완료", HttpStatus.OK);
@@ -77,7 +79,7 @@ public class CartController {
    */
   @DeleteMapping("/remove")
   public ResponseEntity<String> deleteCartByUserRequest(
-      @RequestHeader("Authorization") String authorizationHeader) {
+      @RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader) {
     Long userId = jwtUtil.findUserByToken(authorizationHeader);
     cartService.removeCart(userId); // cart는 hard delete 됨
     return new ResponseEntity<>("장바구니 삭제 완료", HttpStatus.OK);

--- a/src/main/java/com/example/playcation/common/PagingDto.java
+++ b/src/main/java/com/example/playcation/common/PagingDto.java
@@ -1,0 +1,14 @@
+package com.example.playcation.common;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PagingDto<T> {
+
+  private final List<T> list;
+
+  private final Long count;
+}

--- a/src/main/java/com/example/playcation/game/controller/GameController.java
+++ b/src/main/java/com/example/playcation/game/controller/GameController.java
@@ -1,22 +1,18 @@
 package com.example.playcation.game.controller;
 
-import com.example.playcation.enums.GameStatus;
+import com.example.playcation.common.PagingDto;
+import com.example.playcation.common.TokenSettings;
 import com.example.playcation.game.dto.CreatedGameRequestDto;
 import com.example.playcation.game.dto.CreatedGameResponseDto;
-import com.example.playcation.game.dto.PagingGameResponseDto;
 import com.example.playcation.game.dto.UpdatedGameRequestDto;
 import com.example.playcation.game.service.GameService;
 import com.example.playcation.gametag.dto.GameListResponseDto;
 import com.example.playcation.gametag.service.GameTagService;
-import com.example.playcation.library.dto.LibraryGameResponseDto;
 import com.example.playcation.library.service.LibraryService;
 import com.example.playcation.util.JWTUtil;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -44,9 +40,9 @@ public class GameController {
   // 게임 생성 컨트롤러
   @PostMapping
   public ResponseEntity<CreatedGameResponseDto> createGame(
-      @RequestHeader String ACCESS_TOKEN_CATEGORY,
+      @RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader,
       @RequestBody CreatedGameRequestDto requestDto) {
-    Long id = jwtUtil.findUserByToken(ACCESS_TOKEN_CATEGORY);
+    Long id = jwtUtil.findUserByToken(authorizationHeader);
     CreatedGameResponseDto responseDto = gameService.createGame(id, requestDto);
     return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
   }
@@ -60,7 +56,7 @@ public class GameController {
 
   //게임 다건 조회 컨트롤러
   @GetMapping
-  public ResponseEntity<PagingGameResponseDto> findGamesAndPaging(
+  public ResponseEntity<PagingDto<CreatedGameResponseDto>> findGamesAndPaging(
       // 조회하고 싶은 페이지(미입력시 자동으로 첫 페이지가 출력)
       @RequestParam(defaultValue = "0") int page,
       // 검색 조건(tag는 게임에서 찾을 수 없음으로 따로 제작)
@@ -69,7 +65,8 @@ public class GameController {
       @RequestParam(required = false) BigDecimal price,
       @RequestParam(required = false) LocalDate createdAt
   ) {
-    PagingGameResponseDto games = gameService.searchGames(page, title, category, price, createdAt.atStartOfDay());
+    PagingDto<CreatedGameResponseDto> games = gameService.searchGames(page, title, category, price,
+        createdAt.atStartOfDay());
     return new ResponseEntity<>(games, HttpStatus.OK);
   }
 
@@ -87,18 +84,19 @@ public class GameController {
   @PatchMapping("/{gameId}")
   public ResponseEntity<CreatedGameResponseDto> updateGame(
       @PathVariable Long gameId,
-      @RequestHeader String ACCESS_TOKEN_CATEGORY,
+      @RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader,
       @RequestPart("dto") UpdatedGameRequestDto requestDto,
       @RequestPart(value = "file", required = false) String imageUrl) {
-    Long userId = jwtUtil.findUserByToken(ACCESS_TOKEN_CATEGORY);
-    CreatedGameResponseDto responseDto = gameService.updateGame(gameId, userId, requestDto, imageUrl);
+    Long userId = jwtUtil.findUserByToken(authorizationHeader);
+    CreatedGameResponseDto responseDto = gameService.updateGame(gameId, userId, requestDto,
+        imageUrl);
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
   @DeleteMapping("/{gameId}")
   public ResponseEntity<String> deleteGame(@PathVariable Long gameId,
-      @RequestHeader String ACCESS_TOKEN_CATEGORY) {
-    Long userId = jwtUtil.findUserByToken(ACCESS_TOKEN_CATEGORY);
+      @RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader) {
+    Long userId = jwtUtil.findUserByToken(authorizationHeader);
 
     gameService.deleteGame(gameId, userId);
     return new ResponseEntity<>("삭제되었습니다", HttpStatus.OK);

--- a/src/main/java/com/example/playcation/game/repository/GameRepositoryCustom.java
+++ b/src/main/java/com/example/playcation/game/repository/GameRepositoryCustom.java
@@ -1,12 +1,14 @@
 package com.example.playcation.game.repository;
 
-import com.example.playcation.game.dto.PagingGameResponseDto;
+import com.example.playcation.common.PagingDto;
+import com.example.playcation.game.dto.CreatedGameResponseDto;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import org.springframework.data.domain.PageRequest;
 
 public interface GameRepositoryCustom {
 
-  PagingGameResponseDto searchGames(PageRequest pageRequest, String title, String category,
+  PagingDto<CreatedGameResponseDto> searchGames(PageRequest pageRequest, String title,
+      String category,
       BigDecimal price, LocalDateTime createdAt);
 }

--- a/src/main/java/com/example/playcation/game/repository/GameRepositoryCustomImpl.java
+++ b/src/main/java/com/example/playcation/game/repository/GameRepositoryCustomImpl.java
@@ -1,5 +1,7 @@
 package com.example.playcation.game.repository;
 
+import com.example.playcation.common.PagingDto;
+import com.example.playcation.game.dto.CreatedGameResponseDto;
 import com.example.playcation.game.dto.PagingGameResponseDto;
 import com.example.playcation.game.entity.Game;
 import com.example.playcation.game.entity.QGame;
@@ -19,7 +21,7 @@ public class GameRepositoryCustomImpl implements GameRepositoryCustom {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public PagingGameResponseDto searchGames(PageRequest pageRequest, String title, String category,
+  public PagingDto<CreatedGameResponseDto> searchGames(PageRequest pageRequest, String title, String category,
       BigDecimal price, LocalDateTime createdAt) {
     QGame game = QGame.game;
 
@@ -45,7 +47,10 @@ public class GameRepositoryCustomImpl implements GameRepositoryCustom {
             afterCreatedAt(createdAt)
         )
         .fetchOne();
-    return new PagingGameResponseDto(gameList, count);
+
+    List<CreatedGameResponseDto> list = gameList.stream().map(CreatedGameResponseDto::toDto)
+        .toList();
+    return new PagingDto<>(list, count);
   }
 
   private BooleanExpression eqTitle(String title) {

--- a/src/main/java/com/example/playcation/game/service/GameService.java
+++ b/src/main/java/com/example/playcation/game/service/GameService.java
@@ -1,6 +1,7 @@
 package com.example.playcation.game.service;
 
 
+import com.example.playcation.common.PagingDto;
 import com.example.playcation.enums.GameStatus;
 import com.example.playcation.exception.GameErrorCode;
 import com.example.playcation.exception.NoAuthorizedException;
@@ -65,7 +66,7 @@ public class GameService {
   }
 
   // 게임 다건 조회
-  public PagingGameResponseDto searchGames(int page, String title, String category, BigDecimal price,
+  public PagingDto<CreatedGameResponseDto> searchGames(int page, String title, String category, BigDecimal price,
       LocalDateTime createdAt) {
 
     // 페이징시 최대 출력 갯수와 정렬조건 설정

--- a/src/main/java/com/example/playcation/gametag/controller/GameTagController.java
+++ b/src/main/java/com/example/playcation/gametag/controller/GameTagController.java
@@ -1,5 +1,6 @@
 package com.example.playcation.gametag.controller;
 
+import com.example.playcation.common.TokenSettings;
 import com.example.playcation.gametag.dto.GameTagRequestDto;
 import com.example.playcation.gametag.dto.GameTagResponseDto;
 import com.example.playcation.gametag.service.GameTagService;
@@ -31,15 +32,15 @@ public class GameTagController {
   }
 
   @PatchMapping("/{gameTagId}")
-  public ResponseEntity<GameTagResponseDto> updateGameTag(@RequestHeader String ACCESS_TOKEN_CATEGORY, @PathVariable Long gameTagId, @RequestBody GameTagRequestDto requestDto) {
-    Long userId = jwtUtil.findUserByToken(ACCESS_TOKEN_CATEGORY);
+  public ResponseEntity<GameTagResponseDto> updateGameTag(@RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader, @PathVariable Long gameTagId, @RequestBody GameTagRequestDto requestDto) {
+    Long userId = jwtUtil.findUserByToken(authorizationHeader);
     GameTagResponseDto responseDto = gameTagService.updateGameTag(userId, gameTagId, requestDto);
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
   @DeleteMapping("/{gameTagId}")
-  public ResponseEntity<String> deleteGameTag(@RequestHeader String ACCESS_TOKEN_CATEGORY, @PathVariable Long gameTagId) {
-    Long userId = jwtUtil.findUserByToken(ACCESS_TOKEN_CATEGORY);
+  public ResponseEntity<String> deleteGameTag(@RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader, @PathVariable Long gameTagId) {
+    Long userId = jwtUtil.findUserByToken(authorizationHeader);
     gameTagService.deleteGame(userId, gameTagId);
     return new ResponseEntity<>("삭제 완료되었습니다", HttpStatus.OK);
   }

--- a/src/main/java/com/example/playcation/library/controller/LibraryController.java
+++ b/src/main/java/com/example/playcation/library/controller/LibraryController.java
@@ -1,5 +1,7 @@
 package com.example.playcation.library.controller;
 
+import com.example.playcation.common.PagingDto;
+import com.example.playcation.common.TokenSettings;
 import com.example.playcation.gametag.dto.GameListResponseDto;
 import com.example.playcation.library.dto.LibraryGameResponseDto;
 import com.example.playcation.library.dto.LibraryListResponseDto;
@@ -11,6 +13,7 @@ import com.example.playcation.util.JWTUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import nonapi.io.github.classgraph.utils.LogNode;
+import org.springframework.data.domain.jaxb.SpringDataJaxb.PageDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -33,9 +36,9 @@ public class LibraryController {
   private final JWTUtil jwtUtil;
 
   @PostMapping
-  public ResponseEntity<LibraryResponseDto> createLibrary(@RequestHeader String ACCESS_TOKEN_CATEGORY,
+  public ResponseEntity<LibraryResponseDto> createLibrary(@RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader,
       @RequestBody LibraryRequestDto requestDto) {
-    Long userId = jwtUtil.findUserByToken(ACCESS_TOKEN_CATEGORY);
+    Long userId = jwtUtil.findUserByToken(authorizationHeader);
     LibraryResponseDto responseDto = libraryService.createLibrary(requestDto, userId);
     return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
   }
@@ -48,25 +51,25 @@ public class LibraryController {
 
   // 다건 조회(라이브러리)
   @GetMapping("/my-games")
-  public ResponseEntity<List<LibraryGameResponseDto>> findLibraryList(@RequestHeader String ACCESS_TOKEN_CATEGORY,
+  public ResponseEntity<PagingDto<LibraryGameResponseDto>> findLibraryList(@RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader,
       @RequestParam(defaultValue = "0") int page) {
-    Long userId = jwtUtil.findUserByToken(ACCESS_TOKEN_CATEGORY);
-    List<LibraryGameResponseDto> responseDto = libraryService.findLibraryList(page, userId);
+    Long userId = jwtUtil.findUserByToken(authorizationHeader);
+    PagingDto<LibraryGameResponseDto> responseDto = libraryService.findLibraryList(page, userId);
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
   @PatchMapping("/{libraryId}")
-  public ResponseEntity<LibraryResponseDto> updateFavourite(@RequestHeader String ACCESS_TOKEN_CATEGORY,
+  public ResponseEntity<LibraryResponseDto> updateFavourite(@RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader,
       @PathVariable Long libraryId, @RequestBody UpdatedFavouriteRequestDto requestDto) {
-    Long userId = jwtUtil.findUserByToken(ACCESS_TOKEN_CATEGORY);
+    Long userId = jwtUtil.findUserByToken(authorizationHeader);
     LibraryResponseDto responseDto = libraryService.updateFavourite(libraryId, requestDto, userId);
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
   @DeleteMapping("/{libraryId}")
-  public ResponseEntity<String> deleteLibrary(@RequestHeader String ACCESS_TOKEN_CATEGORY,
+  public ResponseEntity<String> deleteLibrary(@RequestHeader(TokenSettings.ACCESS_TOKEN_CATEGORY) String authorizationHeader,
       @PathVariable Long libraryId) {
-    Long userId = jwtUtil.findUserByToken(ACCESS_TOKEN_CATEGORY);
+    Long userId = jwtUtil.findUserByToken(authorizationHeader);
     libraryService.deleteLibrary(libraryId, userId);
     return new ResponseEntity<>("삭제되었습니다", HttpStatus.OK);
   }

--- a/src/main/java/com/example/playcation/library/dto/LibraryGameResponseDto.java
+++ b/src/main/java/com/example/playcation/library/dto/LibraryGameResponseDto.java
@@ -12,11 +12,8 @@ public class LibraryGameResponseDto {
 
   private Boolean favourite;
 
-  private Long count;
-
-  public LibraryGameResponseDto(Game game, boolean favourite, Long count) {
+  public LibraryGameResponseDto(Game game, boolean favourite) {
     this.game = CreatedGameResponseDto.toDto(game);
     this.favourite = favourite;
-    this.count = count;
   }
 }

--- a/src/main/java/com/example/playcation/library/service/LibraryService.java
+++ b/src/main/java/com/example/playcation/library/service/LibraryService.java
@@ -1,5 +1,6 @@
 package com.example.playcation.library.service;
 
+import com.example.playcation.common.PagingDto;
 import com.example.playcation.exception.DuplicatedException;
 import com.example.playcation.exception.LibraryErrorCode;
 import com.example.playcation.exception.NoAuthorizedException;
@@ -18,10 +19,12 @@ import com.example.playcation.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.jaxb.SpringDataJaxb.PageDto;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -56,7 +59,7 @@ public class LibraryService {
     return LibraryResponseDto.toDto(library);
   }
 
-  public List<LibraryGameResponseDto> findLibraryList(int page, Long userId) {
+  public PagingDto<LibraryGameResponseDto> findLibraryList(int page, Long userId) {
 
     PageRequest pageRequest = PageRequest.of(page, 10);
 
@@ -66,12 +69,10 @@ public class LibraryService {
 
     List<Library> libraryList = listDto.getLibraryList();
 
-    List<LibraryGameResponseDto> gameList = new ArrayList<>();
-    for (Library library : libraryList) {
-      gameList.add(new LibraryGameResponseDto(library.getGame(), library.getFavourite(), listDto.getCount()));
-    }
+    List<LibraryGameResponseDto> gameList = libraryList.stream()
+        .map(ld -> new LibraryGameResponseDto(ld.getGame(), ld.getFavourite())).toList();
 
-    return gameList;
+    return new PagingDto<>(gameList, listDto.getCount());
 
   }
 

--- a/src/main/java/com/example/playcation/tag/controller/TagController.java
+++ b/src/main/java/com/example/playcation/tag/controller/TagController.java
@@ -41,6 +41,7 @@ public class TagController {
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
+  // TODO: 페이징 방식 통일
   @GetMapping
   public ResponseEntity<List<CreatedTagResponseDto>> findAllTag(
       @RequestParam(defaultValue = "0") int page


### PR DESCRIPTION
PagingDto에 맞게 기존 페이징 처리하던 메서드들 수정
GameController token 상수 값 오류 해결

## #️⃣연관된 이슈

> #23 

## 📝작업 내용

일관성 있는 페이징 처리를 위해 `PagingDto` 생성했습니다. 기존에 페이징 처리하던 메서드 일부를 새로 생성한 dto를 반환할 수 있도록 수정했습니다. 페이징 dto 적용법은 아래 작성하겠습니다.

### 스크린샷 (선택)
```java
public class PagingDto<T> {

private final List<T> list;

private final Long count;
}
``` 
PagingDto를 생성할 때 타입에 페이징할 dto를 설정해서 생성해주시면 됩니다.
> **list**: 페이징 처리할 항목 dto
> **count**: 항목 총 개수

ex) 
```java
List<LibraryGameResponseDto> gameList = libraryList.stream()
    .map(ld -> new LibraryGameResponseDto(ld.getGame(), ld.getFavourite())).toList();

return new PagingDto<>(gameList, listDto.getCount());
```

![image](https://github.com/user-attachments/assets/6a9812bf-ac91-4468-a2fc-bc60aa113f25)
위 사진처럼 list 항목 내부에 dto 내용들이 나열됩니다.

## 💬리뷰 요구사항(선택)

> TagController 페이징 방식이 다른 컨트롤러와 달라서 PagingDto 적용을 못했습니다. count가 없는 것 같던데 확인 부탁드립니다!